### PR TITLE
Added github logo in the header and linked to repo 

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,13 @@
 
 <body>
     <div class="header">
-        <img class="header-logo" src="./assets/logo.png" alt="logo">
-        <p class="header-title">Mausam</p>
-        <img src="assets/GitHub-Mark-120px-plus.png" alt="" srcset="">
+        <div class="header-main">
+            <img class="header-logo" src="./assets/logo.png" alt="logo">
+            <p class="header-title">Mausam</p>
+        </div>
+        <a class="header-github-logo" href="https://github.com/ShouryaSrivastava01/weather-application/">
+            <img src="assets/github_logogit .png" alt="" srcset="">
+        </a>
     </div>
     <div class="weather-info">
         <div class="card">

--- a/style.css
+++ b/style.css
@@ -13,10 +13,22 @@ body{
 .header{
     display: flex;
     align-items: center;
+    justify-content: space-between;
     background-color: #b6f3f5;
     font-family: 'Press Start 2P', cursive;
 }
+.header-main{
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
 .header-logo{
+    height: 50px;
+    margin-right: 20px;
+    margin-left: 40px;
+}
+.header-github-logo,
+.header-github-logo img{
     height: 50px;
     margin-right: 20px;
     margin-left: 40px;


### PR DESCRIPTION
Issue solved: #10 
Added the Github logo from assets to the header and linked the logo with current repo

Demo:
[github-logo-link.webm](https://user-images.githubusercontent.com/96634646/193364644-4a70b583-a0c2-4080-aa15-b9eab605387d.webm)

*changes made*
**HTML**
```diff
-  <img class="header-logo" src="./assets/logo.png" alt="logo">
-  <p class="header-title">Mausam</p>
-  <img src="assets/GitHub-Mark-120px-plus.png" alt="" srcset="">
+  <div class="header-main">
+     <img class="header-logo" src="./assets/logo.png" alt="logo">
+      <p class="header-title">Mausam</p>
+  </div>
+  <a class="header-github-logo" href="https://github.com/ShouryaSrivastava01/weather-application/">
+    <img src="assets/github_logogit .png" alt="" srcset="">
+  </a>
```

**CSS**
```diff
// To create space between main logo and github logo
+ .header{
+  justify-content: space-between;
+ }

// to arrange the logo and title in-line
+ .header-main{
+    display: flex;
+   flex-direction: row;
+   align-items: center;
+ }

// to adjust the size of github logo as per figma design
+ .header-github-logo,
+ .header-github-logo img{
+   height: 50px;
+    margin-right: 20px;
+    margin-left: 40px;
+ }

```

Hope this satisfies the given requirement mentioned in the issue. Please mention if there are any required changes.
Thank you